### PR TITLE
Allow user to specify to move/copy/link images

### DIFF
--- a/openfmri2bids/cli.py
+++ b/openfmri2bids/cli.py
@@ -1,22 +1,27 @@
 import click
-from converter import convert
 
+from .converter import convert, NII_HANDLING_OPTS
 
 @click.command()
 @click.argument('openfmri_dataset_path', required=True, type=click.Path(exists=True))
 @click.argument('output_folder', required=True, type=click.Path())
 @click.option('--first_session_label', type=(str))
 @click.option('--additional_session', type=(str, click.Path()), multiple=True)
-def main(openfmri_dataset_path, output_folder, first_session_label, additional_session):
+@click.option('--nii_handling', type=click.Choice(NII_HANDLING_OPTS), default=NII_HANDLING_OPTS[0])
+def main(openfmri_dataset_path, output_folder, first_session_label,
+         additional_session, nii_handling):
     """Convert OpenfMRI dataset to BIDS."""
     click.echo('{0}, {1}.'.format(openfmri_dataset_path, output_folder))
-    
+
     if additional_session:
-        convert(openfmri_dataset_path, output_folder, ses=first_session_label, empty_nii=True)
+        convert(openfmri_dataset_path, output_folder,
+                ses=first_session_label, nii_handling=nii_handling)
         for session in additional_session:
-            convert(session[1], output_folder, ses=session[0], empty_nii=True)
+            convert(session[1], output_folder, ses=session[0],
+                    nii_handling=nii_handling)
     else:
-        convert(openfmri_dataset_path, output_folder, empty_nii=True)
+        convert(openfmri_dataset_path, output_folder,
+                nii_handling=nii_handling)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When converting, a user may want to move, copy, or symbolically link images from the original OpenFMri dataset.

Currently:
- By default, dummy functional files are created, and anatomical images are copied.
- The user can choose to copy the functional files as well through the function, but not via the command-line..

With this change:
- By default, dummy files are created for functional and anatomical images.
- Users can choose to move/copy/symbolically link the images (one parameter for both types of image)
- This choice is exposed on the command-line.

Testing:
- I tested that this works in Python. I haven't tested this on the command-line.
